### PR TITLE
Fixes #63 application name based on variable

### DIFF
--- a/explore-assistant-extension/.env_example
+++ b/explore-assistant-extension/.env_example
@@ -9,3 +9,5 @@ VERTEX_BIGQUERY_LOOKER_CONNECTION_NAME=<This is the connection name that has ver
 VERTEX_BIGQUERY_MODEL_ID=<This is the model id that you want to use for prediction>
 BIGQUERY_EXAMPLE_PROMPTS_CONNECTION_NAME=<The BQ connection name in Looker that has query access to example prompts. This may be the same as the Vertex Connection Name if using just one gcp project>
 BIGQUERY_EXAMPLE_PROMPTS_DATASET_NAME=<This is the dataset and project that contain the Example prompt data, assuming that differs from the Looker connection>
+
+APPLICATION_NAME=<Defaults to Explore Assistance>

--- a/explore-assistant-extension/README.md
+++ b/explore-assistant-extension/README.md
@@ -104,6 +104,8 @@ jsonPayload.component="explore-assistant-metadata"
    VERTEX_BIGQUERY_MODEL_ID=<This is the model id that you want to use for prediction>
    ```
 
+   If you'd like to customize applicaiton name set up APPLICATION_NAME.
+
 1. If you're utilizing Looker Core (Looker instance hosted in Google Cloud), adjust the `embed_domain` variable within the `useEffect()` function in ExploreEmbed.tsx to reflect the `hostUrl` instead of `window.origin`.
 
    ```typescript
@@ -149,6 +151,8 @@ jsonPayload.component="explore-assistant-metadata"
     }
    }
    ```
+
+   If you prefer a different application (part of the URL) or label (visible in the Application dropdown), select a different value that matches the APPLICATION_NAME variable.
 
 1. Create a `model` LookML file in your project. The name doesn't matter. The model and connection won't be used, and in the future this step may be eliminated.
 

--- a/explore-assistant-extension/src/pages/ExploreAssistantPage/index.tsx
+++ b/explore-assistant-extension/src/pages/ExploreAssistantPage/index.tsx
@@ -15,6 +15,7 @@ import { ExploreEmbed } from '../../components/ExploreEmbed'
 import GeminiLogo from '../../components/GeminiLogo'
 import { ExtensionContext } from '@looker/extension-sdk-react'
 import { useDispatch, useSelector } from 'react-redux'
+import process from 'process'
 import {
   addToHistory,
   setExploreUrl,
@@ -37,6 +38,7 @@ const ExploreAssistantPage = () => {
   const { generateExploreUrl } = useFetchData()
   const [textAreaValue, setTextAreaValue] = React.useState<string>('')
   const { extensionSDK } = useContext(ExtensionContext)
+  const APPLICATION_NAME = process.env.APPLICATION_NAME || 'Explore Assistant'
 
   const {
     exploreUrl,
@@ -134,11 +136,11 @@ const ExploreAssistantPage = () => {
         borderRight={'key'}
       >
         <Heading fontSize={'xxlarge'} fontWeight={'semiBold'}>
-          Explore Assistant
+          {APPLICATION_NAME}
         </Heading>
-        <Paragraph fontSize={'small'} marginBottom={'u4'}>
-          Select data domain and ask questions of a sample Ecommerce dataset
-          powered by the Gemini model on Vertex AI.
+        <Paragraph fontSize={'small'}>
+          Pick a data domain and inquire with the help of the Gemini model on
+          Vertex AI.
         </Paragraph>
         <Box py="u4">
           <ExploreSelect handleSelect={handleSelect} />

--- a/explore-assistant-extension/src/pages/ExploreChatPage/index.tsx
+++ b/explore-assistant-extension/src/pages/ExploreChatPage/index.tsx
@@ -6,6 +6,7 @@ import {
   FieldTextArea,
   Heading,
   Icon,
+  Paragraph,
   Section,
   Space,
   SpaceVertical,
@@ -13,6 +14,7 @@ import {
 } from '@looker/components'
 import React, { FormEvent, useCallback, useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
+import process from 'process'
 import { RootState } from '../../store'
 import useSendVertexMessage from '../../hooks/useSendVertexMessage'
 import SamplePrompts from '../../components/SamplePrompts'
@@ -41,8 +43,8 @@ const ExploreChatPage = () => {
   const { isQuerying, exploreUrl, query, dimensions, measures, examples } =
     useSelector((state: RootState) => state.assistant)
   const [textAreaValue, setTextAreaValue] = React.useState<string>(query)
-
   const { generateExploreUrl } = useSendVertexMessage()
+  const APPLICATION_NAME = process.env.APPLICATION_NAME || 'Explore Assistant'
 
   useEffect(() => {
     if (
@@ -144,7 +146,7 @@ const ExploreChatPage = () => {
         >
           <Space between>
             <Heading fontSize={'xxlarge'} fontWeight={'semiBold'}>
-              Explore Assistant
+              {APPLICATION_NAME}
             </Heading>
             {exploreUrl && (
               <ButtonTransparent onClick={reset}>
@@ -161,6 +163,10 @@ const ExploreChatPage = () => {
           ) : (
             <SpaceVertical mt={'u8'} gap={'none'}>
               <Section width={'100%'}>
+                <Paragraph fontSize={'small'}>
+                  Pick a data domain and inquire with the help of the Gemini
+                  model on Vertex AI.
+                </Paragraph>
                 <Box py="u4">
                   <ExploreSelect handleSelect={handleSelect} />
                 </Box>

--- a/explore-assistant-extension/src/pages/LandingPage/index.tsx
+++ b/explore-assistant-extension/src/pages/LandingPage/index.tsx
@@ -10,6 +10,7 @@ import {
   SpaceVertical,
 } from '@looker/components'
 import { NavLink } from 'react-router-dom'
+import process from 'process'
 
 interface DocCardProps {
   title: string
@@ -49,6 +50,7 @@ const DocCard = ({ title, model, description, doc }: DocCardProps) => {
 }
 
 const LandingPage = () => {
+  const APPLICATION_NAME = process.env.APPLICATION_NAME || 'Explore Assistant'
   const docs = [
     {
       title: 'No Code Prompt Tuning',
@@ -68,9 +70,9 @@ const LandingPage = () => {
 
   const logError = (error: Error, info: { componentStack: string }) => {
     // Do something with the error, e.g. log to an external API
-    console.log("Error: ", error)
-    console.log("Info: ", info)
-  };
+    console.log('Error: ', error)
+    console.log('Info: ', info)
+  }
 
   return (
     <SpaceVertical>
@@ -79,9 +81,9 @@ const LandingPage = () => {
         maxWidth={'30rem'}
         margin={'auto'}
         gap={'none'}
-        >
+      >
         <Heading fontSize={'xxxxlarge'} fontWeight={'bold'}>
-          Explore Assistant Demo
+          {APPLICATION_NAME}
         </Heading>
         <Heading color={'inform'} fontSize={'large'} fontWeight={'semiBold'}>
           Powered by Generative AI with Google
@@ -104,9 +106,9 @@ const LandingPage = () => {
                 model={doc.model}
                 description={doc.description}
                 doc={doc.doc}
-                />
-                )
-              })}
+              />
+            )
+          })}
         </SpaceVertical>
       </SpaceVertical>
     </SpaceVertical>


### PR DESCRIPTION
If target user choses to rebrand explore assistant to something else, certain headers / titles should be configurable.